### PR TITLE
Add robots.txt at base url

### DIFF
--- a/config/templates/robots.txt
+++ b/config/templates/robots.txt
@@ -1,0 +1,2 @@
+user-agent: *
+disallow: /

--- a/config/urls.py
+++ b/config/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 """
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic import TemplateView
 
 from config.views import IndexView
 
@@ -26,4 +27,5 @@ urlpatterns = [
     path('accounts/', include('allauth.urls')),
     path('parser/', include('config.parser.urls')),
     path('admin/', admin.site.urls),
+    path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain'))
 ]


### PR DESCRIPTION
- **add robots.txt**
- **add robots.txt as url**

I will translate it tomorrow

===

This robots.txt disallows crawling of the whole site.
Please keep in mind that it can still be crawled if there are links/mentions
to our site on other sites, where crawling is allowed.

To prevent the site from being indexed, we should use noindex one of these ways:
1) meta tag in <head> of all htmls (base.html is enough, since we inherit all htmls from it)
<meta name="robots" content="noindex">
2) HTTP response header
X-Robots-Tag: noindex

However if we wish to use noindex method, we should allow crawling
- because to reach noindex crawlers need to crawl the site.

I think robots.txt method is more flexible and safe enough.
