### PR TITLE
docs: fix typo in Redux Toolkit description

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SPA веб-приложение. Единый портал для анализа
 
 - Typescript
 - React 19
-- Redux Toolkit: упраление состоянием
+- Redux Toolkit: управление состоянием
 - React Router: клиентский роутинг
 - React Hook Form: формы
 - Vite


### PR DESCRIPTION
## Summary
Fixed typo in Redux Toolkit description: `упраление` → `управление`

## Changes
- Corrected spelling error in line 14 of README.md

Small documentation improvement to enhance readability.