### PR TITLE
WIP: Feat/demo screenshots component

### DIFF
--- a/frontend/src/components/pages/Channels.tsx
+++ b/frontend/src/components/pages/Channels.tsx
@@ -18,6 +18,7 @@ import {
   mapCategoryCountEntry,
 } from '@/utils/reduceChannels.ts';
 import channelsCol from '@/fixtures/channelsCollection.ts';
+import { CheckIcon } from '@heroicons/react/24/outline';
 
 const defaultChannels = channelsCol;
 
@@ -96,18 +97,7 @@ const Channels: React.FC<ChannelsProps> = ({ channels = defaultChannels }) => {
             <h2 className="text-md md:text-xl lg:text-2xl font-bold ">
               Верифицированные подборки
             </h2>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="size-5 md:size-6 text-blue-500"
-            >
-              <path
-                fillRule="evenodd"
-                d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z"
-                clipRule="evenodd"
-              />
-            </svg>
+            <CheckIcon className="size-5 md:size-6 text-blue-500"/>
           </div>
           <div className="w-full p-5 h-55 py-5 border flex flex-col md:flex-row items-center justify-center gap-5 bg-background rounded-md shadow-md">
             <ul className="w-full grid md:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ScreenshotsDemo from '../ui/ScreenshotsDemo';
+import screenshotsDemoColl from '@/fixtures/screenshotsDemoCollection';
 
 const Home: React.FC = () => {
   return (
@@ -22,7 +23,7 @@ const Home: React.FC = () => {
 
       <div className="w-full bg-gray-50">
         <div className="max-w-xs md:max-w-2xl lg:max-w-4xl xl:max-w-7xl mx-auto py-20 px-5">
-          <ScreenshotsDemo />
+          <ScreenshotsDemo screenshots={screenshotsDemoColl}/>
         </div>
       </div>
     </div>

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -1,9 +1,30 @@
-import React from "react";
+import React from 'react';
+import ScreenshotsDemo from '../ui/ScreenshotsDemo';
 
 const Home: React.FC = () => {
   return (
-    <div className="max-w-7xl mx-auto">
-      <h1 className='py-5 text-4xl font-bold'>Главная страница</h1>
+    <div className="w-full bg-blue-50 items-center justify-center">
+      <div className="w-full h-150 bg-linear-to-t from-white to-blue-50 flex justify-center">
+        <div className="max-w-xs md:max-w-2xl lg:max-w-4xl xl:max-w-7xl mx-auto py-20 px-5">
+          <div className="h-100 w-full flex gap-5 pb-10">
+            <div>
+              <h1 className="py-5 text-4xl font-bold">
+                Аналитика Telegram + тренды +
+                <span className="text-blue-500"> ИИ-помощник</span>
+              </h1>
+            </div>
+            <div className="h-full w-200 bg-gray-100 border-2">
+              TG Analytics Dashboard
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="w-full bg-gray-50">
+        <div className="max-w-xs md:max-w-2xl lg:max-w-4xl xl:max-w-7xl mx-auto py-20 px-5">
+          <ScreenshotsDemo />
+        </div>
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/ui/ScreenshotsDemo.tsx
+++ b/frontend/src/components/ui/ScreenshotsDemo.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { Button } from './button';
+
+const arr = ['Dashboard', 'Подборки', 'ИИ-помощник'];
+
+const ScreenshotsDemo: React.FC = () => {
+  return (
+    <div className="w-full">
+      <div className="flex justify-between items-center pb-10">
+        <div>
+          <h2 className="text-2xl font-bold pb-3">Скриншоты продукта</h2>
+          <p>Дашборды, подборки, ИИ-чат и мониторинг - готово из коробки.</p>
+        </div>
+          <Button className='bg-blue-500'>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="size-5"
+            >
+              <path
+                fillRule="evenodd"
+                d="M4.606 12.97a.75.75 0 0 1-.134 1.051 2.494 2.494 0 0 0-.93 2.437 2.494 2.494 0 0 0 2.437-.93.75.75 0 1 1 1.186.918 3.995 3.995 0 0 1-4.482 1.332.75.75 0 0 1-.461-.461 3.994 3.994 0 0 1 1.332-4.482.75.75 0 0 1 1.052.134Z"
+                clipRule="evenodd"
+              />
+              <path
+                fillRule="evenodd"
+                d="M5.752 12A13.07 13.07 0 0 0 8 14.248v4.002c0 .414.336.75.75.75a5 5 0 0 0 4.797-6.414 12.984 12.984 0 0 0 5.45-10.848.75.75 0 0 0-.735-.735 12.984 12.984 0 0 0-10.849 5.45A5 5 0 0 0 1 11.25c.001.414.337.75.751.75h4.002ZM13 9a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"
+                clipRule="evenodd"
+              />
+            </svg>
+            Открыть демо
+          </Button>
+      </div>
+      <div>
+        <ul className="flex gap-5">
+          {arr.map((item) => (
+            <li className="h-100 w-100 border">{item}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default ScreenshotsDemo;

--- a/frontend/src/components/ui/ScreenshotsDemo.tsx
+++ b/frontend/src/components/ui/ScreenshotsDemo.tsx
@@ -1,41 +1,44 @@
 import React from 'react';
 import { Button } from './button';
+import { RocketLaunchIcon } from '@heroicons/react/24/outline';
+import type { Screenshot, ScreenshotsProps } from '@/types/screenshots';
+import screenshotsDemoCollection from '@/fixtures/screenshotsDemoCollection';
 
-const arr = ['Dashboard', 'Подборки', 'ИИ-помощник'];
+const defaultScreenshots = screenshotsDemoCollection;
 
-const ScreenshotsDemo: React.FC = () => {
+const ScreenshotsDemo: React.FC<ScreenshotsProps> = ({
+  screenshots = defaultScreenshots,
+}) => {
   return (
     <div className="w-full">
       <div className="flex justify-between items-center pb-10">
         <div>
           <h2 className="text-2xl font-bold pb-3">Скриншоты продукта</h2>
-          <p>Дашборды, подборки, ИИ-чат и мониторинг - готово из коробки.</p>
+          <p className="text-gray-700">
+            Дашборды, подборки, ИИ-чат и мониторинг - готово из коробки.
+          </p>
         </div>
-          <Button className='bg-blue-500'>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="size-5"
-            >
-              <path
-                fillRule="evenodd"
-                d="M4.606 12.97a.75.75 0 0 1-.134 1.051 2.494 2.494 0 0 0-.93 2.437 2.494 2.494 0 0 0 2.437-.93.75.75 0 1 1 1.186.918 3.995 3.995 0 0 1-4.482 1.332.75.75 0 0 1-.461-.461 3.994 3.994 0 0 1 1.332-4.482.75.75 0 0 1 1.052.134Z"
-                clipRule="evenodd"
-              />
-              <path
-                fillRule="evenodd"
-                d="M5.752 12A13.07 13.07 0 0 0 8 14.248v4.002c0 .414.336.75.75.75a5 5 0 0 0 4.797-6.414 12.984 12.984 0 0 0 5.45-10.848.75.75 0 0 0-.735-.735 12.984 12.984 0 0 0-10.849 5.45A5 5 0 0 0 1 11.25c.001.414.337.75.751.75h4.002ZM13 9a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"
-                clipRule="evenodd"
-              />
-            </svg>
-            Открыть демо
-          </Button>
+        <Button className="bg-blue-500">
+          <RocketLaunchIcon />
+          Открыть демо
+        </Button>
       </div>
       <div>
-        <ul className="flex gap-5">
-          {arr.map((item) => (
-            <li className="h-100 w-100 border">{item}</li>
+        <ul className="flex flex-wrap gap-5">
+          {screenshots.map((item: Screenshot) => (
+            <li
+              key={item.name}
+              className="h-100 w-100 border rounded-xl bg-white relative"
+            >
+              <img
+                src={item.image}
+                alt=""
+                className="absolute inset-0 w-full h-full object-cover rounded-xl"
+              />
+              <a href="" className="absolute bottom-5 left-5">
+                {item.name}
+              </a>
+            </li>
           ))}
         </ul>
       </div>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,5 +1,5 @@
-@import "tailwindcss";
-@import "tw-animate-css";
+@import 'tailwindcss';
+@import 'tw-animate-css';
 
 @custom-variant dark (&:is(.dark *));
 
@@ -61,9 +61,6 @@ body {
   }
   a:hover {
     color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
   }
 }
 
@@ -145,5 +142,9 @@ body {
   }
   body {
     @apply bg-background text-foreground;
+  }
+  button:not(:disabled),
+  [role='button']:not(:disabled) {
+    cursor: pointer;
   }
 }

--- a/frontend/src/types/screenshots.ts
+++ b/frontend/src/types/screenshots.ts
@@ -1,0 +1,10 @@
+interface Screenshot {
+  name: string;
+  image: string;
+}
+
+interface ScreenshotsProps {
+  screenshots: Screenshot[];
+}
+
+export type { Screenshot, ScreenshotsProps };


### PR DESCRIPTION
issue #111 
Добавлен компонент со скриншотами(демонстрацией работы), который отображается на главной странице.

Структура props:

const screenshotsProps: = [
    {
      name: 'Dashboard',
      image: '',
    },
    {
      name: 'Подборки',
      image: '',
    },
    {
      name: 'ИИ-помощник',
      image: '',
    },
];

Дефолтное значение props прописано в фикстурах и подключается, если не передан другой props.
Планируется доработка адаптивной версии под mobile, tablet.

<img width="1332" height="1204" alt="Снимок экрана 2025-10-27 в 17 23 23" src="https://github.com/user-attachments/assets/df9a52ef-7d82-47c0-b746-d0df43b8e1ac" />
