### PR TITLE
ci(tests): update uv setup and add format check in workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,10 @@ jobs:
         id: cache-uv
         uses: actions/cache@v3
         with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
+          path: 
+          - ~/.cache/uv 
+          - .venv
+          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock', 'pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-uv-
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,16 +19,26 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+        uses: astral-sh/setup-uv@v6
 
       - name: Cache uv dependencies
+        id: cache-uv
         uses: actions/cache@v3
         with:
           path: ~/.cache/uv
           key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
           restore-keys: |
             ${{ runner.os }}-uv-
+
+      - name: Install uv dependencies
+        if: steps.cache-uv.outputs.cache-hit != 'true'
+        run: uv sync
+
+      - name: Run backend linter
+        run: uv run ruff check .
+
+      - name: Run backend formatter
+        run: uv run ruff format --check
 
       - name: Install project and test deps
         run: |
@@ -67,10 +77,6 @@ jobs:
           ./cc-test-reporter format-coverage -t coverage.py -o coverage/codeclimate.json
           ./cc-test-reporter upload-coverage
           ./cc-test-reporter after-build --exit-code $?
-
-      - name: Run linter
-        run: 
-          uv run ruff check .
 
       - name: Upload django logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Issue #387 

## Что изменено

Обновлён GitHub Actions workflow `.github/workflows/tests.yml`:

- Установка `uv` выполняется через официальный экшен `astral-sh/setup-uv@v6` вместо `curl | sh`.
- Добавлен шаг кэширования зависимостей `uv` с условной установкой `uv sync` при промахе кэша.
- Линтер и форматтер (`ruff check` / `ruff format --check`) запускаются до основных тестов.
- Удалён дублирующий шаг линтера в конце workflow.

## Чек-лист

- [x] в CI есть шаги ruff check и ruff format --check
- [x] PR с ошибкой линтера/формата краснеет
- [x] шаги идут после установки зависимостей и не зависят от TELEGRAM_*
