### PR TITLE
ci(tests): simplify uv dependency installation by removing caching step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,20 +20,10 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-
-      - name: Cache uv dependencies
-        id: cache-uv
-        uses: actions/cache@v3
         with:
-          path: 
-          - ~/.cache/uv 
-          - .venv
-          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock', 'pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-
+          enable-cache: true
 
       - name: Install uv dependencies
-        if: steps.cache-uv.outputs.cache-hit != 'true'
         run: uv sync
 
       - name: Run backend linter


### PR DESCRIPTION
CI не запускается из-за ошибки  "Invalid workflow file (Line: 29, Col: 11): A sequence was not expected" - ошибка в отступах:
```
path: 
- ~/.cache/uv 
- .venv
```

Предложение использовать вариант, который рекомендует использовать команда uv.