### PR TITLE
Добавляет единый слой shared props для Inertia (inertia-django)

### DIFF
--- a/apps/homepage/test_views.py
+++ b/apps/homepage/test_views.py
@@ -47,19 +47,23 @@ class IndexViewTest(TestCase):
         )
         self.assertEqual(first_component["order"], self.component.order)
 
-    def test_guest_inertia_props_include_shared_auth_state(self):
+    def _get_inertia_props(self, url_name="main_index"):
         response = self.client.get(
-            reverse("main_index"),
+            reverse(url_name),
             HTTP_ACCEPT="application/json",
             HTTP_X_INERTIA="true",
         )
-
         self.assertEqual(response.status_code, 200)
-        props = response.json()["props"]
+        return response.json()["props"]
+
+    def test_guest_inertia_props_include_shared_auth_state(self):
+        props = self._get_inertia_props()
 
         self.assertIsNone(props["auth"])
         self.assertEqual(props["role"], "guest")
+        self.assertFalse(props["is_admin"])
         self.assertIn("csrfToken", props)
+        self.assertTrue(props["csrfToken"])
         self.assertIsNone(props["flash"])
 
     def test_authenticated_user_inertia_props_include_shared_auth_state(self):
@@ -71,6 +75,51 @@ class IndexViewTest(TestCase):
         )
         self.client.force_login(user)
 
+        props = self._get_inertia_props("homepage:dashboard")
+
+        self.assertEqual(props["auth"]["id"], user.id)
+        self.assertEqual(props["auth"]["email"], user.email)
+        self.assertEqual(props["auth"]["role"], "partner")
+        self.assertEqual(props["role"], "partner")
+        self.assertFalse(props["is_admin"])
+        self.assertIn("csrfToken", props)
+
+    def test_admin_user_shared_props(self):
+        user = User.objects.create_user(
+            username="adminuser",
+            email="admin@example.com",
+            password="secret123",
+            role="admin",
+            is_staff=True,
+        )
+        self.client.force_login(user)
+
+        props = self._get_inertia_props("homepage:dashboard")
+
+        self.assertEqual(props["role"], "admin")
+        self.assertEqual(props["auth"]["role"], "admin")
+        self.assertTrue(props["is_admin"])
+
+    def test_channel_moderator_user_shared_props(self):
+        user = User.objects.create_user(
+            username="moderator",
+            email="moderator@example.com",
+            password="secret123",
+            role="channel_moderator",
+        )
+        self.client.force_login(user)
+
+        props = self._get_inertia_props("homepage:dashboard")
+
+        self.assertEqual(props["role"], "channel_moderator")
+        self.assertEqual(props["auth"]["role"], "channel_moderator")
+        self.assertFalse(props["is_admin"])
+
+    def test_flash_message_persists_after_redirect(self):
+        session = self.client.session
+        session["flash"] = {"success": "Пользователь успешно зарегистрирован"}
+        session.save()
+
         response = self.client.get(
             reverse("main_index"),
             HTTP_ACCEPT="application/json",
@@ -81,8 +130,108 @@ class IndexViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         props = response.json()["props"]
 
-        self.assertEqual(props["auth"]["id"], user.id)
-        self.assertEqual(props["auth"]["email"], user.email)
-        self.assertEqual(props["auth"]["role"], "partner")
-        self.assertEqual(props["role"], "partner")
-        self.assertIn("csrfToken", props)
+        self.assertEqual(
+            props["flash"], {"success": "Пользователь успешно зарегистрирован"}
+        )
+
+        # Flash должен быть извлечён из сессии однократно
+        self.assertIsNone(self.client.session.get("flash"))
+
+    def test_flash_survives_chain_of_redirects(self):
+        """Flash не теряется на промежуточном редиректе."""
+        user = User.objects.create_user(
+            username="redirectuser",
+            email="redirect@example.com",
+            password="secret123",
+            role="user",
+        )
+        self.client.force_login(user)
+        session = self.client.session
+        session["flash"] = {"success": "Сообщение через redirect"}
+        session.save()
+
+        # /home перенаправляет авторизованных на /dashboard
+        response = self.client.get(
+            reverse("main_index"),
+            HTTP_ACCEPT="application/json",
+            HTTP_X_INERTIA="true",
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        final_url = response.redirect_chain[-1][0]
+        self.assertIn("dashboard", final_url)
+
+        props = response.json()["props"]
+        self.assertEqual(
+            props["flash"], {"success": "Сообщение через redirect"}
+        )
+
+    def test_unknown_role_fallback_to_user(self):
+        user = User.objects.create_user(
+            username="unknownrole",
+            email="unknown@example.com",
+            password="secret123",
+            role="something_weird",
+        )
+        self.client.force_login(user)
+
+        props = self._get_inertia_props("homepage:dashboard")
+
+        self.assertEqual(props["role"], "user")
+        self.assertEqual(props["auth"]["role"], "user")
+        self.assertFalse(props["is_admin"])
+
+    def test_is_admin_true_for_superuser(self):
+        user = User.objects.create_user(
+            username="superuser",
+            email="super@example.com",
+            password="secret123",
+            role="user",
+            is_superuser=True,
+        )
+        self.client.force_login(user)
+
+        props = self._get_inertia_props("homepage:dashboard")
+
+        self.assertEqual(props["role"], "user")
+        self.assertTrue(props["is_admin"])
+
+    def test_invalid_flash_values_normalized_to_none(self):
+        for invalid_flash in ["", "plain string", {}, []]:
+            with self.subTest(flash=invalid_flash):
+                session = self.client.session
+                session["flash"] = invalid_flash
+                session.save()
+
+                props = self._get_inertia_props()
+                self.assertIsNone(props["flash"])
+                self.assertIsNone(self.client.session.get("flash"))
+
+    def test_registration_flash_survives_redirect_chain(self):
+        """Регистрация устанавливает flash и редиректит на главную."""
+        response = self.client.post(
+            reverse("users:user_create"),
+            data={
+                "first_name": "Test",
+                "last_name": "User",
+                "username": "testregister",
+                "password1": "ComplexPass123!",
+                "password2": "ComplexPass123!",
+                "email": "testregister@example.com",
+                "bio": "",
+                "avatar_image": "",
+                "terms": "on",
+            },
+            follow=True,
+            HTTP_ACCEPT="application/json",
+            HTTP_X_INERTIA="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        props = response.json()["props"]
+        self.assertEqual(
+            props["flash"], {"success": "Пользователь успешно зарегистрирован"}
+        )
+        self.assertTrue(User.objects.filter(username="testregister").exists())

--- a/apps/homepage/test_views.py
+++ b/apps/homepage/test_views.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from apps.homepage.models import HomePageComponent
+from apps.users.models import User
 
 
 class IndexViewTest(TestCase):
@@ -45,3 +46,43 @@ class IndexViewTest(TestCase):
             first_component["content"], self.component.content["content"]
         )
         self.assertEqual(first_component["order"], self.component.order)
+
+    def test_guest_inertia_props_include_shared_auth_state(self):
+        response = self.client.get(
+            reverse("main_index"),
+            HTTP_ACCEPT="application/json",
+            HTTP_X_INERTIA="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        props = response.json()["props"]
+
+        self.assertIsNone(props["auth"])
+        self.assertEqual(props["role"], "guest")
+        self.assertIn("csrfToken", props)
+        self.assertIsNone(props["flash"])
+
+    def test_authenticated_user_inertia_props_include_shared_auth_state(self):
+        user = User.objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="secret123",
+            role="partner",
+        )
+        self.client.force_login(user)
+
+        response = self.client.get(
+            reverse("main_index"),
+            HTTP_ACCEPT="application/json",
+            HTTP_X_INERTIA="true",
+            follow=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        props = response.json()["props"]
+
+        self.assertEqual(props["auth"]["id"], user.id)
+        self.assertEqual(props["auth"]["email"], user.email)
+        self.assertEqual(props["auth"]["role"], "partner")
+        self.assertEqual(props["role"], "partner")
+        self.assertIn("csrfToken", props)

--- a/apps/homepage/views.py
+++ b/apps/homepage/views.py
@@ -72,8 +72,7 @@ class DashboardView(View):
                 "Добавить канал",
                 "Экспорт данных",
                 "Настройки"
-            ],
-            "csrfToken": "abc123xyz456..."
+            ]
         },
         "url": "/dashboard/"
     }

--- a/apps/homepage/views.py
+++ b/apps/homepage/views.py
@@ -1,4 +1,3 @@
-from django.middleware.csrf import get_token
 from django.shortcuts import redirect
 from django.views import View
 from inertia import render as inertia_render
@@ -98,8 +97,5 @@ class DashboardView(View):
         return inertia_render(
             request,
             "Dashboard",
-            props={
-                **dto.model_dump(mode="json"),
-                "csrfToken": get_token(request),
-            },
+            props={**dto.model_dump(mode="json")},
         )

--- a/apps/parser/views.py
+++ b/apps/parser/views.py
@@ -154,7 +154,6 @@ class ParserView(UserAuthenticationCheckMixin, FormView):
 
 class ParserListView(ListView):
     model = TelegramChannel
-    token = "TEMP_TOKEN"
 
     def get(
         self,
@@ -167,10 +166,7 @@ class ParserListView(ListView):
         return inertia_render(
             request,
             "ChannelAnalytics",
-            props={
-                "channels": channels,
-                "csrfToken": self.token,
-            },
+            props={"channels": channels},
         )
 
 

--- a/apps/users/middleware.py
+++ b/apps/users/middleware.py
@@ -15,7 +15,12 @@ class RoleMiddleware:
         role_obj = Role.objects.filter(code=user_role).first()
 
         # Если роль пользователя не найдена, ставим гостевую роль
-        final_role = role_obj.name if role_obj else "guest"
+        if role_obj:
+            final_role = role_obj.code
+        elif user_role:
+            final_role = user_role
+        else:
+            final_role = "guest"
 
         # Ставим роль в запрос
         request.role = final_role

--- a/apps/users/middleware.py
+++ b/apps/users/middleware.py
@@ -15,13 +15,10 @@ class RoleMiddleware:
         role_obj = Role.objects.filter(code=user_role).first()
 
         # Если роль пользователя не найдена, ставим гостевую роль
-        final_role = role_obj.name if role_obj else "Guest"
+        final_role = role_obj.name if role_obj else "guest"
 
         # Ставим роль в запрос
         request.role = final_role
         response = self.get_response(request)
-
-        # !!!!!! Для деплоя эту отдалдку удалить!!!!!!!
-        print(f"Middleware: Current role of the user is '{request.role}'")
 
         return response

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -262,10 +262,10 @@ class UserRegister(View):
             if not user.avatar_image:
                 user.avatar_image = DEFAULT_AVATAR_URL
             user.save()
-            request.session["flash_success"] = (
-                "Пользователь успешно зарегистрирован"
-            )
-            return redirect("/home")
+            request.session["flash"] = {
+                "success": "Пользователь успешно зарегистрирован"
+            }
+            return redirect(reverse("main_index"))
         return inertia_render(
             request,
             "FormRegistration",
@@ -336,9 +336,9 @@ class UserUpdate(UserAuthenticationCheckMixin, View):
                 request, "UpdateUserProfile", props={"form": data, "errors": {}}
             )
 
-        request.session["flash_error"] = (
-            "У вас нет прав для изменения другого пользователя."
-        )
+        request.session["flash"] = {
+            "error": "У вас нет прав для изменения другого пользователя."
+        }
         return redirect(reverse("users:profile"))
 
     def post(self, request, *args, **kwargs):
@@ -347,7 +347,7 @@ class UserUpdate(UserAuthenticationCheckMixin, View):
         form = UserUpdateForm(data=request.POST, instance=user)
         if form.is_valid():
             form.save()
-            request.session["flash_success"] = "Профиль успешно изменен."
+            request.session["flash"] = {"success": "Профиль успешно изменен."}
             return redirect(reverse("users:profile"))
 
         data = {
@@ -374,11 +374,11 @@ class AvatarChangeView(View):
         avatar_form = AvatarChange(data=request.POST, instance=user)
         if avatar_form.is_valid():
             avatar_form.save()
-            request.session["flash_success"] = "Аватар успешно изменен"
+            request.session["flash"] = {"success": "Аватар успешно изменен"}
             return redirect(reverse("users:profile"))
         if avatar_form.errors.get("avatar_url"):
             avatar_url = avatar_form.errors.get("avatar_url").as_text()
-            request.session["flash_error"] = f"{avatar_url[1:]}"
+            request.session["flash"] = {"error": f"{avatar_url[1:]}"}
         return redirect(reverse("users:profile"))
 
 
@@ -410,10 +410,12 @@ class RestorePasswordRequestView(View):
                 use_https=request.is_secure(),
                 email_template_name="emails/restore-password-email.html",
             )
-            request.session["flash_success"] = (
-                "Ссылка на восстановление пароля \
-                отправлена на указанный вами Email"
-            )
+            request.session["flash"] = {
+                "success": (
+                    "Ссылка на восстановление пароля "
+                    "отправлена на указанный вами Email"
+                )
+            }
             return redirect("users:login")
         return inertia_render(
             request,
@@ -457,26 +459,26 @@ class RestorePasswordView(View):
             token = None
 
         if uid is None or token is None:
-            request.session["flash_error"] = (
-                "Некорректная ссылка для восстановления пароля"
-            )
+            request.session["flash"] = {
+                "error": "Некорректная ссылка для восстановления пароля"
+            }
             return redirect("users:login")
 
         try:
             uid_decoded = urlsafe_base64_decode(uid).decode()
         except TypeError:
-            request.session["flash_error"] = "Некорректный id пользователя"
+            request.session["flash"] = {"error": "Некорректный id пользователя"}
             return redirect("users:login")
         try:
             user = User.objects.get(pk=uid_decoded)
         except User.DoesNotExist:
-            request.session["flash_error"] = "Пользователь не найден"
+            request.session["flash"] = {"error": "Пользователь не найден"}
             return redirect("users:login")
 
         if not default_token_generator.check_token(user, token):
-            request.session["flash_error"] = (
-                "Некорректная ссылка для восстановления пароля"
-            )
+            request.session["flash"] = {
+                "error": "Некорректная ссылка для восстановления пароля"
+            }
             return redirect("users:login")
 
         return inertia_render(
@@ -501,32 +503,32 @@ class RestorePasswordView(View):
             token = None
 
         if uid is None or token is None:
-            request.session["flash_error"] = (
-                "Некорректная ссылка для восстановления пароля"
-            )
+            request.session["flash"] = {
+                "error": "Некорректная ссылка для восстановления пароля"
+            }
             return redirect("users:login")
 
         try:
             uid_decoded = urlsafe_base64_decode(uid).decode()
         except TypeError:
-            request.session["flash_error"] = "Некорректный id пользователя"
+            request.session["flash"] = {"error": "Некорректный id пользователя"}
             return redirect("users:login")
         try:
             user = User.objects.get(pk=uid_decoded)
         except User.DoesNotExist:
-            request.session["flash_error"] = "Пользователь не найден"
+            request.session["flash"] = {"error": "Пользователь не найден"}
             return redirect("users:login")
 
         if not default_token_generator.check_token(user, token):
-            request.session["flash_error"] = (
-                "Некорректная ссылка для восстановления пароля"
-            )
+            request.session["flash"] = {
+                "error": "Некорректная ссылка для восстановления пароля"
+            }
             return redirect("users:login")
 
         form = RestorePasswordForm(user=user, data=request.POST)
         if form.is_valid():
             form.save()
-            request.session["flash_success"] = "Пароль успешно изменен"
+            request.session["flash"] = {"success": "Пароль успешно изменен"}
             return redirect("users:login")
 
         return inertia_render(

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.contrib import auth, messages
 from django.contrib.auth import login
 from django.contrib.auth.tokens import default_token_generator
-from django.middleware.csrf import get_token
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils import timezone
@@ -142,7 +141,6 @@ class UserCabinetView(UserAuthenticationCheckMixin, View):
                 "first_name": user.first_name,
                 "email": user.email,
             },
-            "csrfToken": get_token(request),
             "subscription": {
                 "plan": "Pro",
                 "price": "$29",

--- a/config/decorators.py
+++ b/config/decorators.py
@@ -97,11 +97,11 @@ def guest_required(view_func=None, login_url=None, message=None):
 
 def user_required(view_func=None, login_url=None, message=None):
     """
-    Для всех авторизованных пользователей (user и partner).
+    Для всех авторизованных пользователей.
     Гостей перенаправляет на страницу входа.
     """
     actual_decorator = role_required(
-        allowed_roles=["user", "partner"],
+        allowed_roles=["user", "partner", "admin", "channel_moderator"],
         login_url=login_url or reverse("login"),
         message=message or "Требуется авторизация",
     )

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -2,53 +2,83 @@ from django.middleware.csrf import get_token
 from inertia.share import share
 
 
-class InertiaMiddleware:
+class SharedInertiaPropsMiddleware:
+    """Канонический слой общих Inertia-props.
+
+    См. docs/inertia-shared-props.md
+    """
+
+    VALID_ROLES = {
+        "guest",
+        "user",
+        "partner",
+        "admin",
+        "channel_moderator",
+    }
+
     def __init__(self, get_response):
         self.get_response = get_response
+
+    def _get_role(self, request):
+        if not request.user.is_authenticated:
+            return "guest"
+
+        # Канонический источник — request.role (устанавливается RoleMiddleware).
+        role = getattr(request, "role", None)
+        if role is None:
+            role = getattr(request.user, "role", None)
+
+        normalized_role = str(role).strip().lower() if role else "user"
+        if normalized_role in self.VALID_ROLES:
+            return normalized_role
+
+        return "user"
+
+    def _is_admin(self, request):
+        if not request.user.is_authenticated:
+            return False
+
+        role = self._get_role(request)
+        return (
+            role == "admin"
+            or getattr(request.user, "is_staff", False)
+            or getattr(request.user, "is_superuser", False)
+        )
 
     def _get_auth_payload(self, request):
         if not request.user.is_authenticated:
             return None
 
         user = request.user
-        role = getattr(user, "role", None) or "user"
-        normalized_role = str(role).strip().lower()
+        role = self._get_role(request)
 
         return {
             "id": user.id,
             "name": user.get_full_name() or user.username,
             "email": user.email,
             "avatar_url": user.avatar_image or "",
-            "role": normalized_role,
+            "role": role,
         }
-
-    def _get_role(self, request):
-        if not request.user.is_authenticated:
-            return "guest"
-
-        role = getattr(request.user, "role", None) or getattr(
-            request, "role", None
-        )
-        if role is None:
-            return "user"
-
-        normalized_role = str(role).strip().lower()
-        if normalized_role in {"guest", "user", "partner"}:
-            return normalized_role
-
-        return "user"
 
     def __call__(self, request):
         flash = request.session.pop("flash", None)
-        if isinstance(flash, dict) and not flash:
+        if not isinstance(flash, dict) or not flash:
             flash = None
 
         share(
             request,
             auth=self._get_auth_payload(request),
             role=self._get_role(request),
+            is_admin=self._is_admin(request),
             csrfToken=get_token(request),
             flash=flash,
         )
         response = self.get_response(request)
+
+        # Flash не должен теряться на промежуточных редиректах:
+        # если ответ — redirect, возвращаем flash в сессию,
+        # чтобы следующий запрос мог его извлечь.
+        if flash is not None and 300 <= response.status_code < 400:
+            request.session["flash"] = flash
+
         return response

--- a/config/middleware.py
+++ b/config/middleware.py
@@ -1,0 +1,54 @@
+from django.middleware.csrf import get_token
+from inertia.share import share
+
+
+class InertiaMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def _get_auth_payload(self, request):
+        if not request.user.is_authenticated:
+            return None
+
+        user = request.user
+        role = getattr(user, "role", None) or "user"
+        normalized_role = str(role).strip().lower()
+
+        return {
+            "id": user.id,
+            "name": user.get_full_name() or user.username,
+            "email": user.email,
+            "avatar_url": user.avatar_image or "",
+            "role": normalized_role,
+        }
+
+    def _get_role(self, request):
+        if not request.user.is_authenticated:
+            return "guest"
+
+        role = getattr(request.user, "role", None) or getattr(
+            request, "role", None
+        )
+        if role is None:
+            return "user"
+
+        normalized_role = str(role).strip().lower()
+        if normalized_role in {"guest", "user", "partner"}:
+            return normalized_role
+
+        return "user"
+
+    def __call__(self, request):
+        flash = request.session.pop("flash", None)
+        if isinstance(flash, dict) and not flash:
+            flash = None
+
+        share(
+            request,
+            auth=self._get_auth_payload(request),
+            role=self._get_role(request),
+            csrfToken=get_token(request),
+            flash=flash,
+        )
+        response = self.get_response(request)
+        return response

--- a/config/mixins.py
+++ b/config/mixins.py
@@ -103,7 +103,7 @@ class GuestRequiredMixin(RoleRequiredMixin):
 class UserRequiredMixin(RoleRequiredMixin):
     """Для всех авторизованных пользователей"""
 
-    allowed_roles = ["user", "partner", "channel_moderator"]
+    allowed_roles = ["user", "partner", "admin", "channel_moderator"]
     permission_denied_message = "Требуется авторизация"
 
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -109,6 +109,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
     "inertia.middleware.InertiaMiddleware",
+    "config.middleware.InertiaMiddleware",
     "apps.users.middleware.RoleMiddleware",
 ]
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -109,8 +109,8 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "allauth.account.middleware.AccountMiddleware",
     "inertia.middleware.InertiaMiddleware",
-    "config.middleware.InertiaMiddleware",
     "apps.users.middleware.RoleMiddleware",
+    "config.middleware.SharedInertiaPropsMiddleware",
 ]
 
 

--- a/config/views.py
+++ b/config/views.py
@@ -58,15 +58,7 @@ class IndexView(View):
                 }
             )
 
-        # Flach сообщение временное явление, пока не будет готова
-        # на фронте страница login. Сейчас представление UserRegister
-        # делает редирект с сообщением на главную страницу
-
-        flash = {}
-        if "flash_success" in request.session:
-            flash["success"] = request.session.pop("flash_success")
-
-        page_props = {"components": components_data, "flash": flash}
+        page_props = {"components": components_data}
 
         # коментируем до изменеий в UserRegister
         # page_props = {

--- a/docs/inertia-shared-props.md
+++ b/docs/inertia-shared-props.md
@@ -1,0 +1,81 @@
+# Inertia shared props
+
+Каждый Inertia-ответ проекта содержит канонический набор общих props. Они формируются в `config.middleware.InertiaMiddleware` и являются единственным источником состояния авторизации, CSRF-токена и flash-сообщений для фронтенда.
+
+## Контракт
+
+```json
+{
+  "auth": null | {
+    "id": number,
+    "name": string,
+    "email": string,
+    "avatar_url": string | null,
+    "role": "guest" | "user" | "partner" | "admin" | "channel_moderator"
+  },
+  "role": "guest" | "user" | "partner" | "admin" | "channel_moderator",
+  "is_admin": boolean,
+  "csrfToken": string,
+  "flash": null | { "success"?: string, "error"?: string }
+}
+```
+
+### auth
+
+Объект авторизованного пользователя или `null` для гостя.
+
+| Поле | Описание |
+|------|----------|
+| `id` | PK пользователя |
+| `name` | `get_full_name()` или `username` |
+| `email` | Email пользователя |
+| `avatar_url` | URL аватара или пустая строка |
+| `role` | Роль пользователя в нижнем регистре |
+
+### role
+
+Текущая роль сессии. Гости всегда получают `"guest"`. Авторизованные пользователи получают одну из ролей: `"user"`, `"partner"`, `"admin"`, `"channel_moderator"`.
+
+### is_admin
+
+`true`, если пользователь имеет роль `"admin"`, является staff (`is_staff`) или superuser (`is_superuser`). Для гостя — `false`.
+
+### csrfToken
+
+Токен CSRF для текущей сессии. Единственное место его формирования — `config.middleware.InertiaMiddleware`. Не дублировать вручную во views.
+
+### flash
+
+Одноразовое сообщение из сессии.
+
+```json
+{"success": "Пользователь успешно зарегистрирован"}
+{"error": "Недостаточно прав"}
+```
+
+Записывается перед redirect:
+
+```python
+request.session["flash"] = {"success": "Профиль изменён."}
+return redirect(...)
+```
+
+Middleware извлекает его через `request.session.pop("flash", None)` и передаёт в props. Использование отдельных ключей `flash_success` / `flash_error` запрещено.
+
+## Правило расширения
+
+Смежные задачи, которым нужно добавить новое общее поле (например, `show_upgrade_banner`), **не создают собственный `share()`**. Они расширяют `config.middleware.InertiaMiddleware`:
+
+```python
+# config/middleware.py
+share(
+    request,
+    auth=...,
+    role=...,
+    csrfToken=...,
+    flash=...,
+    show_upgrade_banner=...,
+)
+```
+
+Это единственный слой определения общих props.


### PR DESCRIPTION
Issue #195 

## Что изменено

- Новый `config.middleware.SharedInertiaPropsMiddleware` — на каждый Inertia-ответ добавляет канонические общие props:
  - `auth` — `{ id, name, email, avatar_url, role }` для авторизованного пользователя, `null` для гостя;
  - `role` — `"guest" | "user" | "partner" | "admin" | "channel_moderator"`;
  - `is_admin` — `boolean`;
  - `csrfToken`;
  - `flash` — `{ success?: string, error?: string } | null`.
- Подключение middleware в `config/settings.py` после `apps.users.middleware.RoleMiddleware`, чтобы `request.role` был доступен как единый источник роли.
- Унифицирован формат flash: все `request.session["flash_success"]` и `request.session["flash_error"]` заменены на `request.session["flash"] = { "success": ... }` / `{ "error": ... }`. Middleware сохраняет flash в сессию на промежуточных редиректах, чтобы сообщение доходило до целевой страницы.
- Дедупликация: убрано ручное добавление `csrfToken` из примера в docstring `DashboardView` и убрана ручная обработка `flash` в `IndexView`.
- Обновлены `UserRequiredMixin` и `user_required` декоратор: в список авторизованных ролей добавлены `admin` и `channel_moderator`.
- Исправлен редирект после регистрации: `redirect("/home")` заменён на `redirect(reverse("main_index"))`.
- Добавлена документация контракта shared props: `docs/inertia-shared-props.md`.
- Тесты: `apps/homepage/test_views.py` проверяет shared props для гостя, авторизованных пользователей с ролями `partner`, `admin`, `channel_moderator`, fallback для неизвестной роли, `is_admin` для staff/superuser, flash после редиректа и реальный сценарий регистрации.

## Критерии приёмки

- [x] Каждый ответ Inertia включает `auth` (user|null), `role`, `is_admin`, `csrfToken`, `flash`.
- [x] Гости получают `auth=null` и `role="guest"`.
- [x] Авторизованные пользователи получают объект `auth` и свою `role`.
- [x] `csrfToken` больше не добавляется вручную в каждом view.
- [x] Контракт общих props задокументирован в `docs/inertia-shared-props.md`.
- [x] Формат flash унифицирован и сообщение доходит до фронтенда после редиректа.

