### PR TITLE
update command make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ s:
 	uv run python manage.py start_telegram_session
 
 test:
-	python3 -m pytest --tb=short -q
+	uv run pytest --tb=short -q
 
 install:
 	uv sync


### PR DESCRIPTION
**В Makefile обновлена команда `make test`**: 

- теперь используется uv run, 
- флаги --tb=short и -q оставила.