### PR TITLE
Backend: Inertia-view + DTO/сервис для списка блога (featured + сетка)

### DIFF
--- a/apps/blog/dto/blog_dto.py
+++ b/apps/blog/dto/blog_dto.py
@@ -21,7 +21,8 @@ class ArticleCardDTO(BaseModel):
 
 
 class BlogListDTO(BaseModel):
-    """Props для Inertia-страницы 'Blog' (/blog/).
+    """
+    Props для Inertia-страницы 'Blog' (/blog/).
 
     - featured: выделенная статья (последняя is_featured & is_published);
     - articles: остальные статьи, упорядоченные по published_at desc.

--- a/apps/blog/dto/blog_dto.py
+++ b/apps/blog/dto/blog_dto.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ArticleCardDTO(BaseModel):
+    """Карточка статьи для списка блога."""
+
+    id: int
+    slug: str
+    title: str
+    excerpt: str
+    cover_image: str = ""
+    category: str
+    tags: List[str] = Field(default_factory=list)
+    read_time: int = Field(ge=0)
+    published_at: Optional[datetime] = None
+    views_count: int = Field(ge=0)
+    author_name: Optional[str] = None
+
+
+class BlogListDTO(BaseModel):
+    """Props для Inertia-страницы 'Blog' (/blog/).
+
+    - featured: выделенная статья (последняя is_featured & is_published);
+    - articles: остальные статьи, упорядоченные по published_at desc.
+    """
+
+    featured: Optional[ArticleCardDTO] = None
+    articles: List[ArticleCardDTO]

--- a/apps/blog/services/blog_list_service.py
+++ b/apps/blog/services/blog_list_service.py
@@ -1,0 +1,73 @@
+from typing import Optional
+
+from django.db.models import QuerySet
+
+from apps.blog.dto.blog_dto import ArticleCardDTO, BlogListDTO
+from apps.blog.models import BlogArticle
+
+
+class BlogListService:
+    """
+    Собирает данные для страницы списка блога (Inertia 'Blog', /blog/).
+
+    Возвращает:
+    - featured: последняя опубликованная статья с is_featured=True;
+    - articles: все остальные опубликованные статьи (без featured),
+      отсортированные по published_at desc.
+    """
+
+    def build(self) -> BlogListDTO:
+        featured = self._get_featured_article()
+        articles_qs = self._get_articles_queryset(featured)
+
+        return BlogListDTO(
+            featured=self._to_card(featured) if featured else None,
+            articles=[self._to_card(article) for article in articles_qs],
+        )
+
+    # ------------------------
+    # QuerySets
+    # ------------------------
+
+    def _get_featured_article(self) -> Optional[BlogArticle]:
+        return (
+            BlogArticle.objects.filter(is_published=True, is_featured=True)
+            .order_by("-published_at", "-created_at")
+            .select_related("author")
+            .first()
+        )
+
+    def _get_articles_queryset(
+        self, featured: Optional[BlogArticle]
+    ) -> QuerySet[BlogArticle]:
+        qs = BlogArticle.objects.filter(is_published=True).select_related(
+            "author"
+        )
+        if featured is not None:
+            qs = qs.exclude(pk=featured.pk)
+        return qs.order_by("-published_at", "-created_at")
+
+    # ------------------------
+    # Mappers
+    # ------------------------
+
+    def _to_card(self, article: BlogArticle) -> ArticleCardDTO:
+        return ArticleCardDTO(
+            id=article.id,
+            slug=article.slug,
+            title=article.title,
+            excerpt=article.excerpt,
+            cover_image=article.cover_image,
+            category=article.category,
+            tags=list(article.tags or []),
+            read_time=article.read_time,
+            published_at=article.published_at,
+            views_count=article.views_count,
+            author_name=self._get_author_name(article),
+        )
+
+    def _get_author_name(self, article: BlogArticle) -> Optional[str]:
+        author = article.author
+        if author is None:
+            return None
+        return author.get_full_name() or author.username

--- a/apps/blog/tests/test_services.py
+++ b/apps/blog/tests/test_services.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timezone
+
+from django.test import TestCase
+
+from apps.blog.dto.blog_dto import ArticleCardDTO, BlogListDTO
+from apps.blog.models import BlogArticle
+from apps.blog.services.blog_list_service import BlogListService
+
+
+class BlogListServiceTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.featured = BlogArticle.objects.create(
+            title="Главная статья",
+            slug="glavnaya-statya",
+            excerpt="Анонс главной статьи.",
+            is_featured=True,
+            is_published=True,
+            published_at=datetime(2026, 8, 4, 8, 0, tzinfo=timezone.utc),
+        )
+
+        cls.article = BlogArticle.objects.create(
+            title="Обычная статья",
+            slug="obychnaya-statya",
+            excerpt="Анонс обычной статьи.",
+            is_featured=False,
+            is_published=True,
+            published_at=datetime(2026, 7, 10, 9, 0, tzinfo=timezone.utc),
+        )
+
+        cls.unpublished = BlogArticle.objects.create(
+            title="Черновик",
+            slug="chernovik",
+            excerpt="Ещё не опубликовано.",
+            is_featured=False,
+            is_published=False,
+        )
+
+    def test_build_returns_blog_list_dto(self) -> None:
+        dto = BlogListService().build()
+
+        self.assertIsInstance(dto, BlogListDTO)
+        self.assertIsInstance(dto.featured, ArticleCardDTO)
+        self.assertTrue(
+            all(isinstance(article, ArticleCardDTO) for article in dto.articles)
+        )
+
+        self.assertEqual(dto.featured.slug, self.featured.slug)
+
+        articles_slugs = [article.slug for article in dto.articles]
+        self.assertEqual(articles_slugs, [self.article.slug])
+        self.assertNotIn(self.unpublished.slug, articles_slugs)

--- a/apps/blog/tests/test_views.py
+++ b/apps/blog/tests/test_views.py
@@ -1,0 +1,188 @@
+from datetime import datetime, timezone
+from typing import Any
+
+from django.test import TestCase
+from django.urls import reverse
+
+from apps.blog.models import BlogArticle
+from apps.users.models import User
+
+CARD_FIELDS = {
+    "id",
+    "slug",
+    "title",
+    "excerpt",
+    "cover_image",
+    "category",
+    "tags",
+    "read_time",
+    "published_at",
+    "views_count",
+    "author_name",
+}
+
+
+class BlogListViewTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.author = User.objects.create_user(
+            username="blog_author",
+            email="blog_author@example.com",
+            password="secret123",
+            role="partner",
+            first_name="Иван",
+            last_name="Иванов",
+        )
+
+        cls.featured = BlogArticle.objects.create(
+            title="Главная статья",
+            slug="glavnaya-statya",
+            excerpt="Анонс главной статьи.",
+            cover_image="https://example.com/cover.jpg",
+            author=cls.author,
+            category="dev",
+            tags=["python"],
+            is_featured=True,
+            is_published=True,
+            published_at=datetime(2026, 8, 4, 8, 0, tzinfo=timezone.utc),
+            read_time=12,
+            views_count=120,
+        )
+
+        cls.article_recent = BlogArticle.objects.create(
+            title="Свежая статья",
+            slug="svezhaya-statya",
+            excerpt="Анонс свежей статьи.",
+            author=cls.author,
+            category="telegram",
+            tags=["telegram"],
+            is_featured=False,
+            is_published=True,
+            published_at=datetime(2026, 7, 28, 14, 35, tzinfo=timezone.utc),
+            read_time=6,
+            views_count=40,
+        )
+
+        cls.article_middle = BlogArticle.objects.create(
+            title="Средняя статья",
+            slug="srednyaya-statya",
+            excerpt="Анонс средней статьи.",
+            category="ai",
+            tags=["ai"],
+            is_featured=False,
+            is_published=True,
+            published_at=datetime(2026, 7, 10, 9, 0, tzinfo=timezone.utc),
+            read_time=5,
+            views_count=10,
+        )
+
+        cls.article_old = BlogArticle.objects.create(
+            title="Старая статья",
+            slug="staraya-statya",
+            excerpt="Анонс старой статьи.",
+            category="marketing",
+            tags=["marketing"],
+            is_featured=False,
+            is_published=True,
+            published_at=datetime(2026, 7, 5, 14, 0, tzinfo=timezone.utc),
+            read_time=8,
+            views_count=5,
+        )
+
+        cls.unpublished = BlogArticle.objects.create(
+            title="Черновик",
+            slug="chernovik",
+            excerpt="Ещё не опубликовано.",
+            is_featured=False,
+            is_published=False,
+        )
+
+        cls.featured_unpublished = BlogArticle.objects.create(
+            title="Черновик featured",
+            slug="chernovik-featured",
+            excerpt="Featured, но не опубликовано.",
+            is_featured=True,
+            is_published=False,
+        )
+
+    def _get_inertia_props(self) -> dict[str, Any]:
+        response = self.client.get(
+            reverse("blog:list"),
+            HTTP_ACCEPT="application/json",
+            HTTP_X_INERTIA="true",
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()["props"]
+
+    def test_reverse_blog_list_url(self) -> None:
+        self.assertEqual(reverse("blog:list"), "/blog/")
+
+    def test_view_returns_blog_component_and_props(self) -> None:
+        response = self.client.get(
+            reverse("blog:list"),
+            HTTP_ACCEPT="application/json",
+            HTTP_X_INERTIA="true",
+        )
+        self.assertEqual(response.status_code, 200)
+
+        # Inertia-обёртка
+        data = response.json()
+        self.assertIn("component", data)
+        self.assertIn("props", data)
+        self.assertIn("url", data)
+
+        self.assertEqual(data["component"], "Blog")
+        self.assertEqual(data["url"], "/blog/")
+
+        props = data["props"]
+        self.assertIn("featured", props)
+        self.assertIn("articles", props)
+
+    def test_featured_is_latest_published_featured(self) -> None:
+        props = self._get_inertia_props()
+
+        featured = props["featured"]
+        self.assertIsNotNone(featured)
+        # Не подхватываем неопубликованную featured-статью
+        self.assertEqual(featured["slug"], self.featured.slug)
+
+    def test_featured_card_contains_all_fields(self) -> None:
+        props = self._get_inertia_props()
+
+        featured = props["featured"]
+        self.assertEqual(set(featured.keys()), CARD_FIELDS)
+        self.assertEqual(featured["author_name"], "Иван Иванов")
+        self.assertEqual(featured["tags"], ["python"])
+        self.assertEqual(featured["category"], "dev")
+
+    def test_only_published_articles_returned(self) -> None:
+        props = self._get_inertia_props()
+
+        articles_slugs = {article["slug"] for article in props["articles"]}
+        self.assertNotIn(self.unpublished.slug, articles_slugs)
+        self.assertNotIn(self.featured_unpublished.slug, articles_slugs)
+
+    def test_featured_excluded_from_articles(self) -> None:
+        props = self._get_inertia_props()
+
+        featured_slug = props["featured"]["slug"]
+        articles_slugs = {article["slug"] for article in props["articles"]}
+        self.assertNotIn(featured_slug, articles_slugs)
+
+    def test_articles_sorted_by_published_at_desc(self) -> None:
+        props = self._get_inertia_props()
+
+        slugs = [article["slug"] for article in props["articles"]]
+        self.assertEqual(
+            slugs,
+            [
+                self.article_recent.slug,
+                self.article_middle.slug,
+                self.article_old.slug,
+            ],
+        )
+
+    def test_articles_at_least_three(self) -> None:
+        props = self._get_inertia_props()
+
+        self.assertGreaterEqual(len(props["articles"]), 3)

--- a/apps/blog/urls.py
+++ b/apps/blog/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from apps.blog.views import BlogListView
+
+app_name = "blog"
+
+urlpatterns = [
+    path("", BlogListView.as_view(), name="list"),
+]

--- a/apps/blog/views.py
+++ b/apps/blog/views.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse
+from django.views import View
+
+from apps.blog.services.blog_list_service import BlogListService
+from config.renderers import render_inertia_from_dto
+
+
+class BlogListView(View):
+    """
+    Inertia view для публичного списка блога (/blog/).
+
+    Пример Inertia payload для фронтенда (значения пока иллюстративные):
+
+    {
+        "component": "Blog",
+        "props": {
+            "featured": {
+                "id": 1,
+                "slug": "podborka-plaginov-dlya-vs-code-selectel",
+                "title": "Подборка плагинов для VS Code",
+                "excerpt": "Какие расширения реально экономят часы рутины.",
+                "cover_image": "https://example.com/cover.jpg",
+                "category": "dev",
+                "tags": ["vs code", "плагины"],
+                "read_time": 12,
+                "published_at": "2026-08-04T08:00:00+00:00",
+                "views_count": 120,
+                "author_name": "Иван Иванов"
+            },
+            "articles": [
+                {
+                    "id": 2,
+                    "slug": "sut-asinhronnosti-v-python",
+                    "title": "Суть асинхронности в Python",
+                    "excerpt": "Корутины, событийный цикл и таски без магии.",
+                    "cover_image": "https://example.com/cover2.jpg",
+                    "category": "dev",
+                    "tags": ["python", "asyncio"],
+                    "read_time": 8,
+                    "published_at": "2026-07-05T14:00:00+00:00",
+                    "views_count": 89,
+                    "author_name": "Иван Иванов"
+                }
+            ]
+        },
+        "url": "/blog/"
+    }
+
+    Примечания:
+    - отдаются только опубликованные статьи (is_published=True);
+    - featured: последняя статья с is_featured=True, может отсутствовать
+      (тогда фронт получает null и не рисует выделенный блок);
+    - articles: остальные опубликованные статьи без featured,
+      упорядоченные по published_at desc;
+    - страница публичная, авторизация не требуется.
+    """
+
+    def get(
+        self, request: HttpRequest, *args: Any, **kwargs: Any
+    ) -> HttpResponse:
+        dto = BlogListService().build()
+        return render_inertia_from_dto(request, "Blog", props=dto)

--- a/config/urls.py
+++ b/config/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path("dashboard/", include("apps.homepage.urls")),
     path("auth/", include("apps.users.urls")),
     path("group/", include("apps.group_channels.urls")),
+    path("blog/", include("apps.blog.urls")),
     path("accounts/", include("allauth.urls")),
     path("parser/", include("apps.parser.urls")),
     path("admin/", admin.site.urls),


### PR DESCRIPTION
#355

#Что добавлено:
- DTO в `apps/blog/dto/` и `BlogListService` по образцу `DashboardService`: один `featured` (последний `is_featured` & `is_published`)
- `BlogListView` (GET `/blog/` возвращает `Blog`)
- Добавлен `path("blog/", include("apps.blog.urls"))`
- Остальные опубликованные статьи отдаются в `articles` (сетка), без `featured`, по `published_at desc` — фронтенд не фильтрует и не сортирует сам
- Props сериализуются через `render_inertia_from_dto` (`model_dump(mode="json")`)
- Docstring `BlogListView` документирует props и URL
- Тесты в `apps/blog/tests/` (вью + сервис)

#Критерии приёмки
- [x] GET `/blog/` возвращает `Blog`
- [x] props включают `featured` (поля карточки одной статьи) и `articles` (>=3 карточек сетки)
- [x] Возвращаются только опубликованные, `featured` исключена из сетки
- [x] DTO на Pydantic, собираются `BlogListService`
- [x] docstring документирует props+url
- [x] URL зарегистрирован

#Проверка
- `python manage.py test` — 36/36 OK
- `ruff check` / `ruff format --check` — passed
