### PR TITLE
Backend: Inertia-view + DTO/сервис для списка блога (featured + сетка) ч.2

### DIFF
--- a/apps/blog/tests/test_services.py
+++ b/apps/blog/tests/test_services.py
@@ -19,6 +19,15 @@ class BlogListServiceTest(TestCase):
             published_at=datetime(2026, 8, 4, 8, 0, tzinfo=timezone.utc),
         )
 
+        cls.featured_older = BlogArticle.objects.create(
+            title="Старая featured",
+            slug="staraya-featured",
+            excerpt="Тоже в избранном, но опубликована раньше.",
+            is_featured=True,
+            is_published=True,
+            published_at=datetime(2026, 7, 20, 10, 0, tzinfo=timezone.utc),
+        )
+
         cls.article = BlogArticle.objects.create(
             title="Обычная статья",
             slug="obychnaya-statya",
@@ -48,5 +57,7 @@ class BlogListServiceTest(TestCase):
         self.assertEqual(dto.featured.slug, self.featured.slug)
 
         articles_slugs = [article.slug for article in dto.articles]
-        self.assertEqual(articles_slugs, [self.article.slug])
+        self.assertEqual(
+            articles_slugs, [self.featured_older.slug, self.article.slug]
+        )
         self.assertNotIn(self.unpublished.slug, articles_slugs)

--- a/apps/blog/tests/test_views.py
+++ b/apps/blog/tests/test_views.py
@@ -49,6 +49,15 @@ class BlogListViewTest(TestCase):
             views_count=120,
         )
 
+        cls.featured_older = BlogArticle.objects.create(
+            title="Старая featured",
+            slug="staraya-featured",
+            excerpt="Тоже в избранном, но опубликована раньше.",
+            is_featured=True,
+            is_published=True,
+            published_at=datetime(2026, 7, 20, 10, 0, tzinfo=timezone.utc),
+        )
+
         cls.article_recent = BlogArticle.objects.create(
             title="Свежая статья",
             slug="svezhaya-statya",
@@ -143,7 +152,7 @@ class BlogListViewTest(TestCase):
 
         featured = props["featured"]
         self.assertIsNotNone(featured)
-        # Не подхватываем неопубликованную featured-статью
+        # Выбирается самая свежая
         self.assertEqual(featured["slug"], self.featured.slug)
 
     def test_featured_card_contains_all_fields(self) -> None:
@@ -177,6 +186,7 @@ class BlogListViewTest(TestCase):
             slugs,
             [
                 self.article_recent.slug,
+                self.featured_older.slug,
                 self.article_middle.slug,
                 self.article_old.slug,
             ],


### PR DESCRIPTION
#355

#Что добавлено:
- DTO в `apps/blog/dto/` и `BlogListService` по образцу `DashboardService`: один `featured` (последний `is_featured` & `is_published`)
- `BlogListView` (GET `/blog/` возвращает `Blog`)
- Добавлен `path("blog/", include("apps.blog.urls"))`
- Остальные опубликованные статьи отдаются в `articles` (сетка), без `featured`, по `published_at desc` — фронтенд не фильтрует и не сортирует сам
- Props сериализуются через `render_inertia_from_dto` (`model_dump(mode="json")`)
- Docstring `BlogListView` документирует props и URL
- Тесты в `apps/blog/tests/` (вью + сервис)

#Критерии приёмки
- [x] GET `/blog/` возвращает `Blog`
- [x] props включают `featured` (поля карточки одной статьи) и `articles` (>=3 карточек сетки)
- [x] Возвращаются только опубликованные, `featured` исключена из сетки
- [x] DTO на Pydantic, собираются `BlogListService`
- [x] docstring документирует props+url
- [x] URL зарегистрирован

#Проверка
- `python manage.py test` — 36/36 OK
- `ruff check` / `ruff format --check` — passed

#UPD:
- Добавил вторую опубликованную featured-статью с более ранней датой